### PR TITLE
ease off on momentjs-rails dependency

### DIFF
--- a/bootstrap-daterangepicker-rails.gemspec
+++ b/bootstrap-daterangepicker-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   # s.add_dependency('rails', '~>3.2')
   s.add_dependency('railties', '~> 4.0.0')
-  s.add_dependency('momentjs-rails', '~> 2.1.0')
+  s.add_dependency('momentjs-rails', '~> 2.1')
 
   s.add_development_dependency 'test-unit',    '~> 2.2.0'
 


### PR DESCRIPTION
I'm currently working on a project using momentjs-rails v2.3.1 (using [this PR](https://github.com/derekprior/momentjs-rails/pull/17)), and the given dependency causes Bundler to bail out.

As far as I can tell, the changes in [Moment.js](https://github.com/moment/moment/#changelog) should not affect the DateRangePicker, but it's hard to be sure without tests (_hint hint_ ;-))
