### PR TITLE
Remove -bs3 extension suffix from application.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ gem 'coffee-rails'
 # application.js
 
 //= require moment
-//= require daterangepicker-bs3
+//= require daterangepicker
 
 
 # application.css


### PR DESCRIPTION
The gem only includes one daterangepicker.js file, which does not have a -bs2 or -bs3 suffix. Removing this for clarity.
