### PR TITLE
Unclenched railtie version

### DIFF
--- a/bootstrap-daterangepicker-rails.gemspec
+++ b/bootstrap-daterangepicker-rails.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |s|
   s.summary = %q{Rails 3.2.x and Rails 4 plugin to allow for the easy use of Dan Grossman's Bootstrap DateRangePicker}
   s.description = %q{Rails 3.2.x and Rails 4 plugin to allow for the easy use of Dan Grossman's Bootstrap DateRangePicker}
 
-  # s.add_dependency('rails', '~>3.2')
-  s.add_dependency('railties', '~> 4.0.0')
+  s.add_dependency('railties', '>= 4.0.0')
   s.add_dependency('momentjs-rails', '~> 2.1')
 
   s.add_development_dependency 'test-unit',    '~> 2.2.0'


### PR DESCRIPTION
I had made ​​a mistake when pull request before. 
It's disturb to easy the migration to Rails 4.x.
I have loosened the designation of the dependent version of the railtie.
