### PR TITLE
Add Licenses to Gemspec

### DIFF
--- a/bootstrap-daterangepicker-rails.gemspec
+++ b/bootstrap-daterangepicker-rails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/jordanbrock/bootstrap-daterangepicker-rails}
   s.summary = %q{Rails 4.1x plugin to allow for the easy use of Dan Grossman's Bootstrap DateRangePicker}
   s.description = %q{Rails 4.1.x plugin to allow for the easy use of Dan Grossman's Bootstrap DateRangePicker}
+  s.licenses = ["Apache 2.0", "MIT"]
 
   s.add_dependency 'railties', '>= 4.0'
   s.add_development_dependency 'test-unit',    '~> 2.2'


### PR DESCRIPTION
Why:
* The Licenses used by this gem were missing from the Gemspec. This
  prevents automatic means of getting the licenses used by all the gems
  used in a project.

This change addresses the issue by:
* Adding `Apache 2.0` and `MIT` to the licenses attribute in the
  Gemspec.